### PR TITLE
Add volume header, unit tests and CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,15 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install dependencies
+        run: sudo apt-get update && sudo apt-get install -y catch2 g++
+      - name: Build tests
+        run: g++ -std=c++17 tests/test_volume.cpp -I /usr/include/catch2 -lCatch2Main -lCatch2 -o tests/test_volume
+      - name: Run tests
+        run: ./tests/test_volume

--- a/HERVE.ino
+++ b/HERVE.ino
@@ -56,24 +56,8 @@ Measurement measurements[10]; // Tableau pour stocker les 10 dernières mesures
 enum DisplayMode {DISPLAY_VOLUME, DISPLAY_HISTORY, DISPLAY_TIME};
 DisplayMode displayMode = DISPLAY_VOLUME;
 
-// Constantes pour la cuve
-#define RADIUS_INTERIOR 1170 // Rayon intérieur de la cuve en mm
-#define HEIGHT_TRUNCATED 880 // Hauteur du segment tronqué intérieur en mm
-#define HEIGHT_MAX 1520 // Hauteur maximale d'eau dans la cuve en mm
-#define SENSOR_HEIGHT 300 // Hauteur du capteur au-dessus du trop-plein d'eau en mm
-
-// Fonction pour calculer le volume en fonction de la distance mesurée
-float calculateVolume(int distance) {
-  float h = HEIGHT_MAX + SENSOR_HEIGHT - distance * 10; // Conversion de la distance en hauteur d'eau en mm
-  if (h < 0) h = 0;
-  if (h <= HEIGHT_TRUNCATED) {
-    return (M_PI * h * h / 3) * (3 * RADIUS_INTERIOR - h) / 1000; // Formule pour le volume d'un segment sphérique en litres
-  } else {
-    float h_truncated = HEIGHT_MAX - h;
-    return (4.0 / 3.0 * M_PI * RADIUS_INTERIOR * RADIUS_INTERIOR * RADIUS_INTERIOR
-            - M_PI * h_truncated * h_truncated / 3 * (3 * RADIUS_INTERIOR - h_truncated)) / 1000; // Formule pour le volume d'une sphère tronquée en litres
-  }
-}
+// Calcul du volume
+#include "src/volume.h"
 
 void setup() {
   Serial.begin (9600); // Commencer la communication série à 9600 bauds

--- a/README.md
+++ b/README.md
@@ -94,6 +94,19 @@ Voici comment vous pouvez connecter vos composants à l'Arduino Nano :
 4. Dans l'IDE Arduino, sélectionnez le bon port COM pour votre Arduino Nano.
 5. Téléchargez le code sur votre Arduino Nano.
 
+## Tests
+
+Une petite suite de tests unitaires vérifie la fonction `calculateVolume`. Les
+tests utilisent la bibliothèque [Catch2](https://github.com/catchorg/Catch2).
+
+### Compilation et exécution
+
+```bash
+sudo apt-get install catch2 g++
+g++ -std=c++17 tests/test_volume.cpp -I /usr/include/catch2 -lCatch2Main -lCatch2 -o tests/test_volume
+./tests/test_volume
+```
+
 ## Utilisation
 
 Le système dispose de trois boutons qui fonctionnent de la manière suivante :

--- a/src/volume.h
+++ b/src/volume.h
@@ -1,0 +1,24 @@
+#ifndef VOLUME_H
+#define VOLUME_H
+#include <math.h>
+
+// Constants describing the water tank geometry (in mm)
+#define RADIUS_INTERIOR 1170
+#define HEIGHT_TRUNCATED 880
+#define HEIGHT_MAX 1520
+#define SENSOR_HEIGHT 300
+
+// Calculate the volume of water based on measured distance (in cm)
+static inline float calculateVolume(int distance) {
+    float h = HEIGHT_MAX + SENSOR_HEIGHT - distance * 10; // distance cm -> height mm
+    if (h < 0) h = 0;
+    if (h <= HEIGHT_TRUNCATED) {
+        return (M_PI * h * h / 3) * (3 * RADIUS_INTERIOR - h) / 1000;
+    } else {
+        float h_truncated = HEIGHT_MAX - h;
+        return (4.0f / 3.0f * M_PI * RADIUS_INTERIOR * RADIUS_INTERIOR * RADIUS_INTERIOR
+                - M_PI * h_truncated * h_truncated / 3.0f * (3 * RADIUS_INTERIOR - h_truncated)) / 1000;
+    }
+}
+
+#endif // VOLUME_H

--- a/tests/test_volume.cpp
+++ b/tests/test_volume.cpp
@@ -1,0 +1,11 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch_all.hpp>
+#include "../src/volume.h"
+
+TEST_CASE("calculateVolume computes expected volume", "[volume]") {
+    using Catch::Approx;
+    REQUIRE(calculateVolume(200) == Approx(0.0f));
+    REQUIRE(calculateVolume(150) == Approx(342073.363f).epsilon(0.001f));
+    REQUIRE(calculateVolume(100) == Approx(1894124.854f).epsilon(0.001f));
+    REQUIRE(calculateVolume(0) == Approx(6349736.806f).epsilon(0.001f));
+}


### PR DESCRIPTION
## Summary
- extract `calculateVolume` into `src/volume.h`
- unit tests using Catch2
- add workflow to run tests
- document test instructions in README

## Testing
- `g++ -std=c++17 tests/test_volume.cpp -I /usr/include/catch2 -lCatch2Main -lCatch2 -o tests/test_volume && ./tests/test_volume`


------
https://chatgpt.com/codex/tasks/task_e_684145f7ddcc832686ec95928dddac61